### PR TITLE
allow specifying server ami

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+# terraform
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfstate.*.backup
+
+# IDEs
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Before using this module, you'll need to generate a key pair for your server and
 |`wg_client_public_keys`|`list`|Yes|List of maps of client IP/netmasks and public keys. See Usage for details. See Examples for formatting.|
 |`wg_server_port`|`integer`|Optional - defaults to `51820`|Port to run wireguard service on, wireguard standard is 51820.|
 |`wg_persistent_keepalive`|`integer`|Optional - defaults to `25`|Regularity of Keepalives, useful for NAT stability.|
+|`wg_server_private_key_param`|`string`|Optional - defaults to `/wireguard/wg-server-private-key`|The Parameter Store key to use for the VPN server Private Key.|
+|`ami_id`|`string`|Optional - defaults to the newest Ubuntu 16.04 AMI|AMI to use for the VPN server.|
 
 Please see the following examples to understand usage with the relevant options..
 

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
 
 resource "aws_launch_configuration" "wireguard_launch_config" {
   name_prefix                 = "wireguard-${var.env}-"
-  image_id                    = data.aws_ami.ubuntu.id
+  image_id                    = var.ami_id == null ? data.aws_ami.ubuntu.id : var.ami_id
   instance_type               = var.instance_type
   key_name                    = var.ssh_key_id
   iam_instance_profile        = (var.eip_id != "disabled" ? aws_iam_instance_profile.wireguard_profile[0].name : null)

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_launch_configuration" "wireguard_launch_config" {
 }
 
 resource "aws_autoscaling_group" "wireguard_asg" {
-  name                 = "${aws_launch_configuration.wireguard_launch_config.name}"
+  name                 = aws_launch_configuration.wireguard_launch_config.name
   launch_configuration = aws_launch_configuration.wireguard_launch_config.name
   min_size             = var.asg_min_size
   desired_capacity     = var.asg_desired_capacity
@@ -78,7 +78,7 @@ resource "aws_autoscaling_group" "wireguard_asg" {
   tags = [
     {
       key                 = "Name"
-      value               = "${aws_launch_configuration.wireguard_launch_config.name}"
+      value               = aws_launch_configuration.wireguard_launch_config.name
       propagate_at_launch = true
     },
     {
@@ -88,7 +88,7 @@ resource "aws_autoscaling_group" "wireguard_asg" {
     },
     {
       key                 = "env"
-      value               = "${var.env}"
+      value               = var.env
       propagate_at_launch = true
     },
     {

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -1,7 +1,7 @@
 #!/bin/bash -v
 add-apt-repository "ppa:wireguard/wireguard"
 apt-get update -y
-apt-get upgrade -y
+apt-get upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 apt-get install -y wireguard-dkms wireguard-tools awscli
 
 cat > /etc/wireguard/wg0.conf <<- EOF

--- a/variables.tf
+++ b/variables.tf
@@ -77,3 +77,8 @@ variable "wg_server_private_key_param" {
   default     = "/wireguard/wg-server-private-key"
   description = "The SSM parameter containing the WG server private key"
 }
+
+variable "ami_id" {
+  default     = null # we check for this and use a data provider since we can't use it here
+  description = "The AWS AMI to use for the WG server, defaults to the latest Ubuntu 16.04 AMI if not specified."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -43,12 +43,12 @@ variable "wg_server_net" {
 
 variable "wg_server_port" {
   default     = 51820
-  description = "Port for the vpn server"
+  description = "Port for the vpn server."
 }
 
 variable "wg_persistent_keepalive" {
   default     = 25
-  description = "Persistent Keepalive - useful for helping connection stability over NATs"
+  description = "Persistent Keepalive - useful for helping connection stability over NATs."
 }
 
 variable "eip_id" {
@@ -59,23 +59,23 @@ variable "eip_id" {
 variable "additional_security_group_ids" {
   type        = list(string)
   default     = [""]
-  description = "Additional security groups if provided, default empty"
+  description = "Additional security groups if provided, default empty."
 }
 
 variable "target_group_arns" {
   type        = list(string)
   default     = null
-  description = "Running a scaling group behind an LB requires this variable, default null means it won't be included if not set"
+  description = "Running a scaling group behind an LB requires this variable, default null means it won't be included if not set."
 }
 
 variable "env" {
   default     = "prod"
-  description = "The name of environment for WireGuard. Used to differentiate multiple deployments"
+  description = "The name of environment for WireGuard. Used to differentiate multiple deployments."
 }
 
 variable "wg_server_private_key_param" {
   default     = "/wireguard/wg-server-private-key"
-  description = "The SSM parameter containing the WG server private key"
+  description = "The SSM parameter containing the WG server private key."
 }
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,8 @@ variable "env" {
   default     = "prod"
   description = "The name of environment for WireGuard. Used to differentiate multiple deployments"
 }
+
+variable "wg_server_private_key_param" {
+  default     = "/wireguard/wg-server-private-key"
+  description = "The SSM parameter containing the WG server private key"
+}

--- a/wireguard-iam.tf
+++ b/wireguard-iam.tf
@@ -22,10 +22,10 @@ data "aws_iam_policy_document" "wireguard_policy_doc" {
 }
 
 resource "aws_iam_policy" "wireguard_policy" {
-  name               = "tf-wireguard-${var.env}"
-  description        = "Terraform Managed. Allows Wireguard instance to attach EIP."
-  policy             = data.aws_iam_policy_document.wireguard_policy_doc.json
-  count              = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  name        = "tf-wireguard-${var.env}"
+  description = "Terraform Managed. Allows Wireguard instance to attach EIP."
+  policy      = data.aws_iam_policy_document.wireguard_policy_doc.json
+  count       = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
 }
 
 resource "aws_iam_role" "wireguard_role" {
@@ -37,13 +37,13 @@ resource "aws_iam_role" "wireguard_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "wireguard_roleattach" {
-  role               = aws_iam_role.wireguard_role[0].name
-  policy_arn         = aws_iam_policy.wireguard_policy[0].arn
-  count              = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  role       = aws_iam_role.wireguard_role[0].name
+  policy_arn = aws_iam_policy.wireguard_policy[0].arn
+  count      = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
 }
 
 resource "aws_iam_instance_profile" "wireguard_profile" {
-  name               = "tf-wireguard-${var.env}"
-  role               = aws_iam_role.wireguard_role[0].name
-  count              = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
+  name  = "tf-wireguard-${var.env}"
+  role  = aws_iam_role.wireguard_role[0].name
+  count = (var.eip_id != "disabled" ? 1 : 0) # only used for EIP mode
 }

--- a/wireguard-ssm.tf
+++ b/wireguard-ssm.tf
@@ -1,4 +1,3 @@
 data "aws_ssm_parameter" "wg_server_private_key" {
-  name = "/wireguard/wg-server-private-key"
+  name = var.wg_server_private_key_param
 }
-


### PR DESCRIPTION
fyi looks like i had PR'd to master rather than develop last time (oops!) so there are a few commits (the 3 older than 2019-11-20) here that are already in master that will get them synced up.

new changes:
- added a variable to specify the AMI
  - tf was prompting to destroy/recreate whenever there was a new ami
  - if var is not provided we default to the same ami data source as before
- tf syntax cleanup since v0.12.16 is more verbose about warnings
- added some punctuation to the var descriptions, ran `terraform fmt -recursive` on the module
- updated readme with new vars
