### PR TITLE
Drop AWS provider from module

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  version = "~> 2.0"
-}
-
 provider "template" {
   version = "~> 2"
 }
-


### PR DESCRIPTION
It's generally considered best practice to not specify providers in modules, leaving callers to configure those as they see fit. In the case of the AWS provider, you are required--at minimum--to provide a `region` parameter. As written, you have to do the following to invoke the module:

```
module "wg" {
  [other options...]
  providers = {
    aws = aws
  }
}
```

The alternative is requiring a `region` parameter to be passed, but any caller is already setting up their own provider, it seems simpler to just remove it.