### PR TITLE
Fix grub hang

### DIFF
--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -1,5 +1,4 @@
 #!/bin/bash -v
-add-apt-repository "ppa:wireguard/wireguard"
 apt-get update -y
 DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o Dpkg::Options::="--force-confnew"
 apt-get install -y wireguard-dkms wireguard-tools awscli

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -1,7 +1,7 @@
 #!/bin/bash -v
 add-apt-repository "ppa:wireguard/wireguard"
 apt-get update -y
-apt-get upgrade -y -o Dpkg::Options::="--force-confnew"
+DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o Dpkg::Options::="--force-confnew"
 apt-get install -y wireguard-dkms wireguard-tools awscli
 
 cat > /etc/wireguard/wg0.conf <<- EOF


### PR DESCRIPTION
Turns out that a `grub` package update can hang the the user-data script, causing the VPN to fail to come up. This hopefully fixes that. It also removes the now-unneeded wireguard PPA.