### PR TITLE
Add variable for interface name to forward traffic to.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Before using this module, you'll need to generate a key pair for your server and
 |`wg_persistent_keepalive`|`integer`|Optional - defaults to `25`|Regularity of Keepalives, useful for NAT stability.|
 |`wg_server_private_key_param`|`string`|Optional - defaults to `/wireguard/wg-server-private-key`|The Parameter Store key to use for the VPN server Private Key.|
 |`ami_id`|`string`|Optional - defaults to the newest Ubuntu 16.04 AMI|AMI to use for the VPN server.|
+|`wg_server_interface`|`string`|Optional - defaults to eth0|Server interface to route traffic to for installations forwarding traffic to private networks.|
 
 ## Examples
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ data "template_file" "user_data" {
     wg_server_port        = var.wg_server_port
     peers                 = join("\n", data.template_file.wg_client_data_json.*.rendered)
     eip_id                = var.eip_id
+    wg_server_interface   = var.wg_server_interface
   }
 }
 

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -9,8 +9,8 @@ cat > /etc/wireguard/wg0.conf <<- EOF
 Address = ${wg_server_net}
 PrivateKey = ${wg_server_private_key}
 ListenPort = ${wg_server_port}
-PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o ${wg_server_interface} -j MASQUERADE
+PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o ${wg_server_interface} -j MASQUERADE
 
 ${peers}
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,8 @@ variable "ami_id" {
   default     = null # we check for this and use a data provider since we can't use it here
   description = "The AWS AMI to use for the WG server, defaults to the latest Ubuntu 16.04 AMI if not specified."
 }
+
+variable "wg_server_interface" {
+  default     = "eth0"
+  description = "The default interface to forward network traffic to."
+}


### PR DESCRIPTION
Hey, ran into some difficulties on a server that didn't default to eth0.

Would be even better to try to look up the interface name, but this is a good start. Thought others might find it useful too.