### PR TITLE
Disable source destination check for instances that forward traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Before using this module, you'll need to generate a key pair for your server and
 |`wg_persistent_keepalive`|`integer`|Optional - defaults to `25`|Regularity of Keepalives, useful for NAT stability.|
 |`wg_server_private_key_param`|`string`|Optional - defaults to `/wireguard/wg-server-private-key`|The Parameter Store key to use for the VPN server Private Key.|
 |`ami_id`|`string`|Optional - defaults to the newest Ubuntu 16.04 AMI|AMI to use for the VPN server.|
+|`forward_traffic`|`string`|Optional - defaults to false|Will this server be used to forward trafic to a local network.|
 
 ## Examples
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ data "template_file" "user_data" {
     wg_server_port        = var.wg_server_port
     peers                 = join("\n", data.template_file.wg_client_data_json.*.rendered)
     eip_id                = var.eip_id
+    forward_traffic       = var.forward_traffic
   }
 }
 

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -16,11 +16,15 @@ ${peers}
 EOF
 
 # we go with the eip if it is provided
-if [ "${eip_id}" != "disabled" ]; then
+if [ "${eip_id}" != "disabled" ] || [ "${forward_traffic}" == "true" ]; then
   export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
   export REGION=$(curl -fsq http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
-  aws --region $${REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}
-  aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $${INSTANCE_ID} --region $${REGION}
+  if [ "${eip_id}" != "disabled" ]; then
+    aws --region $${REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}
+  fi
+  if [ "${forward_traffic}" == "true" ]; then
+    aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $${INSTANCE_ID} --region $${REGION}
+  fi
 fi
 
 chown -R root:root /etc/wireguard/

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -20,6 +20,7 @@ if [ "${eip_id}" != "disabled" ]; then
   export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
   export REGION=$(curl -fsq http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
   aws --region $${REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}
+  aws ec2 modify-instance-attribute --no-source-dest-check --instance-id $${INSTANCE_ID} --region $${REGION}
 fi
 
 chown -R root:root /etc/wireguard/

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,8 @@ variable "ami_id" {
   default     = null # we check for this and use a data provider since we can't use it here
   description = "The AWS AMI to use for the WG server, defaults to the latest Ubuntu 16.04 AMI if not specified."
 }
+
+variable "forward_traffic" {
+  default     = "false"
+  description = "Will this WireGuard server forward traffic to other hosts on the network?"
+}


### PR DESCRIPTION
EC2 Machines need source-destination check disabled to accept traffic for addresses that are not assigned to them.