### PR TITLE
Get private key in user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # terraform
 .terraform
+.terraform.lock*
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfstate.*.backup

--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,13 @@ data "template_file" "user_data" {
   template = file("${path.module}/templates/user-data.txt")
 
   vars = {
-    wg_server_private_key = data.aws_ssm_parameter.wg_server_private_key.value
-    wg_server_net         = var.wg_server_net
-    wg_server_port        = var.wg_server_port
-    peers                 = join("\n", data.template_file.wg_client_data_json.*.rendered)
-    use_eip               = var.use_eip ? "enabled" : "disabled"
-    eip_id                = var.eip_id
-    wg_server_interface   = var.wg_server_interface
+    wg_server_private_key_param = var.wg_server_private_key_param
+    wg_server_net               = var.wg_server_net
+    wg_server_port              = var.wg_server_port
+    peers                       = join("\n", data.template_file.wg_client_data_json.*.rendered)
+    use_eip                     = var.use_eip ? "enabled" : "disabled"
+    eip_id                      = var.eip_id
+    wg_server_interface         = var.wg_server_interface
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-*-16.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
   filter {
     name   = "virtualization-type"

--- a/templates/user-data.txt
+++ b/templates/user-data.txt
@@ -3,10 +3,18 @@ apt-get update -y
 DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o Dpkg::Options::="--force-confnew"
 apt-get install -y wireguard-dkms wireguard-tools awscli
 
+export AWS_REGION=$(curl -fsq http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
+
+PRIVATE_KEY=$(
+  aws ssm get-parameter --name ${wg_server_private_key_param} \
+  --region $${AWS_REGION} --query='Parameter.Value' \
+  --output=text --with-decryption
+)
+
 cat > /etc/wireguard/wg0.conf <<- EOF
 [Interface]
 Address = ${wg_server_net}
-PrivateKey = ${wg_server_private_key}
+PrivateKey = $${PRIVATE_KEY}
 ListenPort = ${wg_server_port}
 PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o ${wg_server_interface} -j MASQUERADE
 PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o ${wg_server_interface} -j MASQUERADE
@@ -18,7 +26,7 @@ EOF
 if [ "${use_eip}" != "disabled" ]; then
   export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
   export REGION=$(curl -fsq http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
-  aws --region $${REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}
+  aws --region $${AWS_REGION} ec2 associate-address --allocation-id ${eip_id} --instance-id $${INSTANCE_ID}
 fi
 
 chown -R root:root /etc/wireguard/

--- a/wireguard-ssm.tf
+++ b/wireguard-ssm.tf
@@ -1,3 +1,0 @@
-data "aws_ssm_parameter" "wg_server_private_key" {
-  name = var.wg_server_private_key_param
-}


### PR DESCRIPTION
* Update AMI to use latest Ubuntu LTS (20.04)
* Get SSM parameter in user-data script instead of using the Terraform data source. This avoids the security problem of storing the private key in TF state as plaintext. See note in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter#example-usage